### PR TITLE
chore: remove renovate packageRules grouping config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,19 +7,5 @@
 	"rebaseWhen": "never",
 	"major": {
 		"dependencyDashboardApproval": true
-	},
-	"packageRules": [
-		{
-			"groupName": "PostCSS",
-			"matchPackageNames": ["postcss", "postcss-*", "cssnano"]
-		},
-		{
-			"groupName": "Stylelint",
-			"matchPackageNames": ["stylelint", "stylelint-*"]
-		},
-		{
-			"matchUpdateTypes": ["major"],
-			"groupName": null
-		}
-	]
+	}
 }


### PR DESCRIPTION
## Summary

- renovate.json から packageRules（PostCSS / Stylelint のグルーピング設定および major を個別化する設定）を削除

## Why

- 不要になったグルーピング設定を整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)